### PR TITLE
Update for latest ember inspector

### DIFF
--- a/addon/debug-server.js
+++ b/addon/debug-server.js
@@ -10,7 +10,7 @@ var inspectorSocket = null;
 
 // Load the inspector html from the node_modules folder
 // (it should be there because we list it as a dependency)
-var inspectorPath = __dirname + '/../node_modules/ember-inspector/dist_websocket/';
+var inspectorPath = __dirname + '/../node_modules/ember-inspector/dist/websocket/';
 
 // Server static files for the inspector
 remoteDebugger.use('/', express.static(inspectorPath, {index:false}));

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "socket.io":"1.3.5",
-    "ember-inspector": "1.8.0",
+    "ember-inspector": "https://github.com/alexspeller/ember-inspector#master",
     "express": "^4.8.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This change and a patched ember inspector needs to happen first, so filing this PR to show what needs changed.

Presumably the best thing to do is wait until a new inspector release that includes emberjs/ember-inspector#505, then update this PR to point to that version in package.json
